### PR TITLE
📝 Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Go to your project folder that contains a `.env` file.
 ### Send .env file to Heroku environment
 
 ```bash
-$ heroku-dotenv push heroku_app_name
+$ heroku-dotenv push -a heroku_app_name
 ```
 
 ### Save Heroku environment to .env file


### PR DESCRIPTION
An error occurred during the push to Heroku due to the absence of a required flag when running the "heroku config:set" command. To resolve this, the user must include the flag "-a" or "--app" followed by the name of the app they want to run the command on. So I simply added this information to the README.md file accordingly.